### PR TITLE
Change libraryBadge position to its correct location only in search tab.

### DIFF
--- a/src/screens/SearchScreen.tsx
+++ b/src/screens/SearchScreen.tsx
@@ -1297,7 +1297,7 @@ const styles = StyleSheet.create({
   libraryBadge: {
     position: 'absolute',
     top: 8,
-    right: 36,
+    left: 8,
     borderRadius: 8,
     padding: 4,
     zIndex: 2,


### PR DESCRIPTION
The bug batter explained in #172

Fixes issue #172