### PR TITLE
add: current timestamp update while sliding the seek bar on Android

### DIFF
--- a/src/components/player/AndroidVideoPlayer.tsx
+++ b/src/components/player/AndroidVideoPlayer.tsx
@@ -894,7 +894,7 @@ const AndroidVideoPlayer: React.FC = () => {
           isSubtitleModalOpen={modals.showSubtitleModal}
           setShowSourcesModal={modals.setShowSourcesModal}
           setShowEpisodesModal={type === 'series' ? modals.setShowEpisodesModal : undefined}
-          onSliderValueChange={(val) => { playerState.isDragging.current = true; }}
+          onSliderValueChange={(val) => { playerState.isDragging.current = true; playerState.setCurrentTime(val); }}
           onSlidingStart={() => { playerState.isDragging.current = true; }}
           onSlidingComplete={(val) => {
             playerState.isDragging.current = false;

--- a/src/components/player/controls/PlayerControls.tsx
+++ b/src/components/player/controls/PlayerControls.tsx
@@ -278,6 +278,7 @@ export const PlayerControls: React.FC<PlayerControlsProps> = ({
             height: 40,
             marginHorizontal: 0,
           }}
+          step={1}
           minimumValue={0}
           maximumValue={duration || 1}
           value={currentTime}


### PR DESCRIPTION
This change is to make the "current" timestamp update when sliding the seek bar forward/backward on Android. Also, set the slider step value to 1 for smoother per second video seeking.