### PR TITLE
patch: incremental 10 sec skip/rewind on multiple taps

### DIFF
--- a/src/components/player/android/hooks/useDebounceCallback.ts
+++ b/src/components/player/android/hooks/useDebounceCallback.ts
@@ -1,0 +1,33 @@
+import { useCallback, useRef, useEffect } from 'react';
+
+export function useDebounceCallback<T extends (...args: any[]) => void>(
+  callback: T,
+  delay: number
+) {
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const callbackRef = useRef(callback);
+
+  // Sync latest callback to avoid stale closures
+  useEffect(() => {
+    callbackRef.current = callback;
+  }, [callback]);
+
+  const debouncedFunction = useCallback(
+    (...args: Parameters<T>) => {
+      if (timeoutRef.current) clearTimeout(timeoutRef.current);
+      timeoutRef.current = setTimeout(() => {
+        callbackRef.current(...args);
+      }, delay);
+    },
+    [delay]
+  );
+
+  // Cleanup on unmount to prevent memory leaks
+  useEffect(() => {
+    return () => {
+      if (timeoutRef.current) clearTimeout(timeoutRef.current);
+    };
+  }, []);
+
+  return debouncedFunction;
+}

--- a/src/components/player/controls/PlayerControls.tsx
+++ b/src/components/player/controls/PlayerControls.tsx
@@ -7,6 +7,7 @@ import Slider from '@react-native-community/slider';
 import { styles } from '../utils/playerStyles'; // Updated styles
 import { getTrackDisplayName } from '../utils/playerUtils';
 import { useTheme } from '../../../contexts/ThemeContext';
+import { useDebounceCallback } from '../android/hooks/useDebounceCallback';
 
 interface PlayerControlsProps {
   showControls: boolean;
@@ -134,6 +135,15 @@ export const PlayerControls: React.FC<PlayerControlsProps> = ({
   const playIconOpacity = React.useRef(new Animated.Value(1)).current;
 
   /* Handle Seek with Animation */
+  const [skipRewindSeconds, setSkipRewindSeconds] = React.useState(0);
+  const finalSkipRewind = (finalValue: number) => {
+    console.log(`Final value processed: ${finalValue}`);
+    skip(finalValue);
+    setSkipRewindSeconds(0);
+  }
+  const debouncedSkip = useDebounceCallback((val: number) => {
+    finalSkipRewind(val);
+  }, 800);
   const handleSeekWithAnimation = (seconds: number) => {
     const isForward = seconds > 0;
 
@@ -212,7 +222,11 @@ export const PlayerControls: React.FC<PlayerControlsProps> = ({
       arcRotation.setValue(0);
     });
 
-    skip(seconds);
+    setSkipRewindSeconds(prev => {
+      const nextVal = prev + seconds;
+      debouncedSkip(nextVal);
+      return nextVal;
+    });
   };
 
   /* Handle Play/Pause with Animation */


### PR DESCRIPTION
Multiple taps on +10/-10 should skip/rewind incrementally. For example, if +10 is tapped 3 times, the video should skip 30 seconds(3x10).
This change achieves that.