### PR TITLE
fix escape key crashing on macOS

### DIFF
--- a/ios/KSPlayerView.swift
+++ b/ios/KSPlayerView.swift
@@ -19,13 +19,13 @@ class KSPlayerView: UIView {
     weak var viewManager: KSPlayerViewManager?
 
     // Event blocks for Fabric
-    @objc var onExitFullscreen: RCTDirectEventBlock?
     @objc var onLoad: RCTDirectEventBlock?
     @objc var onProgress: RCTDirectEventBlock?
     @objc var onBuffering: RCTDirectEventBlock?
     @objc var onEnd: RCTDirectEventBlock?
     @objc var onError: RCTDirectEventBlock?
     @objc var onBufferingProgress: RCTDirectEventBlock?
+    @objc var onExitFullscreen: RCTDirectEventBlock?
     
     // Property setters that React Native will call
     @objc var source: NSDictionary? {
@@ -101,17 +101,6 @@ class KSPlayerView: UIView {
         super.init(coder: coder)
         setupPlayerView()
     }
-
-    override var canBecomeFirstResponder: Bool {
-        return true
-    }
-
-    override func didMoveToWindow() {
-        super.didMoveToWindow()
-        becomeFirstResponder()
-    }
-
-
 
     private func setupPlayerView() {
         playerView = IOSVideoPlayerView()
@@ -249,10 +238,10 @@ class KSPlayerView: UIView {
         options.registerRemoteControll = false
         
         // PERFORMANCE OPTIMIZATION: Buffer durations for smooth high bitrate playback
-        // preferredForwardBufferDuration = 3.0s: Slightly increased to reduce rebuffering during playback
-        options.preferredForwardBufferDuration = 1.0
-        // maxBufferDuration = 120.0s: Increased to allow the player to cache more content ahead of time (2 minutes)
-        options.maxBufferDuration = 120.0
+        // preferredForwardBufferDuration = 5.0s: Increased to prevent stalling on network hiccups
+        options.preferredForwardBufferDuration = 5.0
+        // maxBufferDuration = 300.0s: Increased to allow 5 minutes of cache ahead
+        options.maxBufferDuration = 300.0
         
         // Enable "second open" to relax startup/seek buffering thresholds (already enabled)
         options.isSecondOpen = true
@@ -325,7 +314,7 @@ class KSPlayerView: UIView {
         } else {
             playerView.play()
         }
-    }
+    }   
 
     override var keyCommands: [UIKeyCommand]? {
         return [


### PR DESCRIPTION
just adds an ignore listener so it doesn't crash, nor do anything