### PR TITLE
Prioritize external meta addons & fix episode ID parsing

### DIFF
--- a/src/hooks/useSettings.ts
+++ b/src/hooks/useSettings.ts
@@ -115,6 +115,8 @@ export interface AppSettings {
   preferredAudioLanguage: string; // Preferred language for audio tracks (ISO 639-1 code)
   subtitleSourcePreference: 'internal' | 'external' | 'any'; // Prefer internal (embedded), external (addon), or any
   enableSubtitleAutoSelect: boolean; // Auto-select subtitles based on preferences
+  // External metadata addon preference
+  preferExternalMetaAddonDetail: boolean; // Prefer metadata from external meta addons on detail page
 }
 
 export const DEFAULT_SETTINGS: AppSettings = {
@@ -203,6 +205,8 @@ export const DEFAULT_SETTINGS: AppSettings = {
   preferredAudioLanguage: 'en', // Default to English audio
   subtitleSourcePreference: 'internal', // Prefer internal/embedded subtitles first
   enableSubtitleAutoSelect: true, // Auto-select subtitles by default
+  // External metadata addon preference
+  preferExternalMetaAddonDetail: false, // Disabled by default
 };
 
 const SETTINGS_STORAGE_KEY = 'app_settings';

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -983,6 +983,8 @@
         "select_catalogs": "Select Catalogs",
         "all_catalogs": "All catalogs",
         "selected": "selected",
+        "prefer_external_meta": "Prefer External Meta Addon",
+        "prefer_external_meta_desc": "Use external metadata on detail page",
         "hero_layout": "Hero Layout",
         "layout_legacy": "Legacy",
         "layout_carousel": "Carousel",

--- a/src/i18n/locales/pl.json
+++ b/src/i18n/locales/pl.json
@@ -983,6 +983,8 @@
         "select_catalogs": "Wybierz katalogi",
         "all_catalogs": "Wszystkie katalogi",
         "selected": "wybrane",
+        "prefer_external_meta": "Preferuj zewnętrzny dodatek meta",
+        "prefer_external_meta_desc": "Używaj zewnętrznych metadanych na stronie szczegółów",
         "hero_layout": "Układ sekcji Hero",
         "layout_legacy": "Klasyczny",
         "layout_carousel": "Karuzela",

--- a/src/screens/HomeScreenSettings.tsx
+++ b/src/screens/HomeScreenSettings.tsx
@@ -344,9 +344,22 @@ const HomeScreenSettings: React.FC = () => {
               colors={colors}
               renderControl={ChevronRight}
               onPress={() => navigation.navigate('HeroCatalogs')}
-              isLast={true}
             />
           )}
+          <SettingItem
+            title={t("home_screen.prefer_external_meta")}
+            description={t("home_screen.prefer_external_meta_desc")}
+            icon="cloud-download"
+            isDarkMode={isDarkMode}
+            colors={colors}
+            renderControl={() => (
+              <CustomSwitch
+                value={settings.preferExternalMetaAddonDetail}
+                onValueChange={(value) => handleUpdateSetting('preferExternalMetaAddonDetail', value)}
+              />
+            )}
+            isLast={true}
+          />
         </SettingsCard>
 
         {settings.showHeroSection && (


### PR DESCRIPTION
Same as for NuvioTV - https://github.com/tapframe/NuvioTV/pull/148

The "**Prefer meta from external addon**" setting toggle is in Display Options

also

Fixed the correct episode ID parsing for non-season formats (mal:id:episode)