### PR TITLE
Fix OpenRouter AI chat failures by defaulting to openrouter/free + custom model override

### DIFF
--- a/src/screens/AIChatScreen.tsx
+++ b/src/screens/AIChatScreen.tsx
@@ -696,8 +696,14 @@ const AIChatScreen: React.FC = () => {
       if (error instanceof Error) {
         if (error.message.includes('not configured')) {
           errorMessage = 'Please configure your OpenRouter API key in Settings > AI Assistant.';
+        } else if (/401|unauthorized|invalid api key|authentication/i.test(error.message)) {
+          errorMessage = 'OpenRouter rejected your API key. Please verify the key in Settings > AI Assistant.';
+        } else if (/insufficient|credit|quota|429/i.test(error.message)) {
+          errorMessage = 'OpenRouter quota/credits were rejected for this request. Please check your OpenRouter usage and limits.';
+        } else if (/model|provider|endpoint|unsupported|unavailable|not found/i.test(error.message)) {
+          errorMessage = 'The selected OpenRouter model is unavailable. Retry with `openrouter/free` or choose another custom model in Settings > AI Assistant.';
         } else if (error.message.includes('API request failed')) {
-          errorMessage = 'Failed to connect to AI service. Please check your internet connection and API key.';
+          errorMessage = 'Failed to connect to AI service. Please check your internet connection, API key, and OpenRouter model availability.';
         }
       }
 


### PR DESCRIPTION
## Summary
This PR fixes AI Chat connection failures when users provide a valid OpenRouter key but the previously hardcoded model is unavailable.

## Root Cause
- `AIService` used a single hardcoded model (`xiaomi/mimo-v2-flash:free`).
- If that model/provider route was unavailable, requests failed with a generic connectivity error.
- There was no UI path to pick a different model for paid users.

## Changes
- Default OpenRouter model switched to `openrouter/free` in `AIService`.
- Added optional custom model configuration in AI settings (`openrouter_model` in storage).
  - Default mode: uses `openrouter/free`.
  - Custom mode: uses exact user-specified model id.
- Kept improved API error parsing so OpenRouter error messages surface better context.
- Improved AI chat error messaging for auth/quota/model-specific failures.
- Ensured AI service re-reads `openrouter_api_key` from storage in config checks to avoid stale in-memory key after updates.

## Files
- `src/services/aiService.ts`
- `src/screens/AISettingsScreen.tsx`
- `src/screens/AIChatScreen.tsx`

## User Impact
- Free-tier users now route through `openrouter/free` by default.
- Paid users can provide a preferred model without code changes.
- Error messages are more actionable when failures occur.