### PR TITLE
Update legal information link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Nuvio functions solely as a client-side interface for browsing metadata and play
 
 Nuvio is not affiliated with any third-party extensions, catalogs, sources, or content providers. It does not host, store, or distribute any media content.
 
-For comprehensive legal information, including our full disclaimer, third-party extension policy, and DMCA/Copyright information, please visit our **[Legal & Disclaimer Page](https://tapframe.github.io/NuvioStreaming/#legal)**.
+For comprehensive legal information, including our full disclaimer, third-party extension policy, and DMCA/Copyright information, please visit our **[Legal & Disclaimer Page](https://nuvioapp.space/legal)**.
 
 ## Built With
 


### PR DESCRIPTION
The old link point to a 404 page from GitHub. I change the legal link to point to the legal page on nuvioapp.space 