### PR TITLE
fix(auth): disable auto-capitalize on password input

### DIFF
--- a/src/screens/AuthScreen.tsx
+++ b/src/screens/AuthScreen.tsx
@@ -406,6 +406,7 @@ const AuthScreen: React.FC = () => {
                     placeholder="Password (min 6 characters)"
                     placeholderTextColor="rgba(255,255,255,0.4)"
                     style={[styles.input, { color: currentTheme.colors.white }]}
+                    autoCapitalize="none"
                     secureTextEntry={!showPassword}
                     value={password}
                     onChangeText={setPassword}
@@ -454,6 +455,7 @@ const AuthScreen: React.FC = () => {
                       placeholder="Confirm password"
                       placeholderTextColor="rgba(255,255,255,0.4)"
                       style={[styles.input, { color: currentTheme.colors.white }]}
+                      autoCapitalize="none"
                       secureTextEntry={!showConfirm}
                       value={confirmPassword}
                       onChangeText={setConfirmPassword}


### PR DESCRIPTION
**What does this PR do?**
Disables the default auto-capitalization behavior on the password and confirm password text input field. 

**Why is this necessary?**
Password fields should not auto-capitalize by default, as passwords are case-sensitive. 

- [x] Tested locally on development build
