### PR TITLE
fix: Sync Setting Screen use correct SafeAreaView 

### DIFF
--- a/src/screens/SyncSettingsScreen.tsx
+++ b/src/screens/SyncSettingsScreen.tsx
@@ -1,7 +1,6 @@
 import React, { useCallback, useMemo, useState } from 'react';
 import {
   ActivityIndicator,
-  SafeAreaView,
   ScrollView,
   StatusBar,
   StyleSheet,
@@ -11,7 +10,7 @@ import {
   View,
 } from 'react-native';
 import { NavigationProp, useFocusEffect, useNavigation } from '@react-navigation/native';
-import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context';
 import { MaterialIcons } from '@expo/vector-icons';
 import { RootStackParamList } from '../navigation/AppNavigator';
 import { useTheme } from '../contexts/ThemeContext';


### PR DESCRIPTION
Use SafeAreaView from 'react-native-safe-area-context' instead of the deprecated one from 'react-native'

The bug is described at Discord https://discord.com/channels/1379902184207941732/1477029029449306358