### PR TITLE
fix(i18n): use languageTag to detect region and select the correct language

### DIFF
--- a/src/i18n/languageDetector.ts
+++ b/src/i18n/languageDetector.ts
@@ -3,30 +3,36 @@ import { LanguageDetectorAsyncModule } from 'i18next';
 import { mmkvStorage } from '../services/mmkvStorage';
 
 const languageDetector: LanguageDetectorAsyncModule = {
-    type: 'languageDetector',
-    async: true,
-    detect: (callback: (lng: string | undefined) => void): void => {
-        const findLanguage = async () => {
-            try {
-                const savedLanguage = await mmkvStorage.getItem('user_language');
-                if (savedLanguage) {
-                    callback(savedLanguage);
-                    return;
-                }
-            } catch (error) {
-                console.log('Error reading language from storage', error);
-            }
+  type: "languageDetector",
+  async: true,
+  detect: (callback: (lng: string | undefined) => void): void => {
+    const findLanguage = async () => {
+      try {
+        const savedLanguage = await mmkvStorage.getItem("user_language");
+        if (savedLanguage) {
+          callback(savedLanguage);
+          return;
+        }
 
-            const locales = getLocales();
-            const languageCode = locales[0]?.languageCode ?? 'en';
-            callback(languageCode);
-        };
-        findLanguage();
-    },
-    init: () => { },
-    cacheUserLanguage: (language: string) => {
-        mmkvStorage.setItem('user_language', language);
-    },
+        const locales = getLocales();
+        if (!locales || locales.length === 0) {
+          callback("en");
+          return;
+        }
+
+        const bestTag = locales[0].languageTag;
+        callback(bestTag);
+      } catch (error) {
+        console.error("[LangDetector(TEST)] Failed to detect language:", error);
+        callback("en");
+      }
+    };
+    findLanguage();
+  },
+  init: () => {},
+  cacheUserLanguage: (language: string) => {
+    mmkvStorage.setItem("user_language", language);
+  },
 };
 
 export default languageDetector;


### PR DESCRIPTION
### languageDetector.ts was with an issue logic to define pt-PT or pt-BR in first launch because had a region difference

**Before Changes:**
<br>
<img src="https://github.com/user-attachments/assets/707c6c35-1188-4339-bcd1-19deee39a8d0" width="400" alt="Before changes" />

<br><br>

**After Changes:**
<br>
<img src="https://github.com/user-attachments/assets/20fcf45b-6e8f-41a4-a742-5ade844db131" width="400" alt="After changes" />