### PR TITLE
feat(ui): add horizontal scroll to download filters

### DIFF
--- a/src/screens/DownloadsScreen.tsx
+++ b/src/screens/DownloadsScreen.tsx
@@ -12,6 +12,7 @@ import {
   Platform,
   Clipboard,
   Linking,
+  ScrollView,
 } from 'react-native';
 import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useNavigation, useFocusEffect } from '@react-navigation/native';
@@ -657,12 +658,17 @@ const DownloadsScreen: React.FC = () => {
         isTablet={isTablet}
       >
         {downloads.length > 0 && (
-          <View style={styles.filterContainer}>
+          <ScrollView
+            horizontal
+            showsHorizontalScrollIndicator={false}
+            style={styles.filterScrollContainer}
+            contentContainerStyle={styles.filterContainer}
+          >
             {renderFilterButton('all', t('downloads.filter_all'), stats.total)}
             {renderFilterButton('downloading', t('downloads.filter_active'), stats.downloading)}
             {renderFilterButton('completed', t('downloads.filter_done'), stats.completed)}
             {renderFilterButton('paused', t('downloads.filter_paused'), stats.paused)}
-          </View>
+          </ScrollView>
         )}
       </ScreenHeader>
 
@@ -745,9 +751,14 @@ const styles = StyleSheet.create({
     padding: 8,
     marginLeft: 8,
   },
+  // testing add scroll
+  filterScrollContainer: {
+    flexGrow: 0,
+  },
   filterContainer: {
     flexDirection: 'row',
     gap: isTablet ? 16 : 12,
+    paddingHorizontal: 16,
   },
   filterButton: {
     flexDirection: 'row',
@@ -756,6 +767,8 @@ const styles = StyleSheet.create({
     paddingVertical: isTablet ? 10 : 8,
     borderRadius: 20,
     gap: 8,
+    flexShrink: 0,
+    minWidth: 'auto',
   },
   filterButtonText: {
     fontSize: isTablet ? 16 : 14,


### PR DESCRIPTION
I noticed that the download filter buttons were being cut off (swallowed) by the screen edges in some languages ​​due to variations in text length. To correct this, I decided to make this change for a responsive and accessible interface in all supported languages, wrapping the filter group in a ScrollView with horizontal properties. This prevents layout breaks and improves the user experience on smaller devices.

ex:

https://private-user-images.githubusercontent.com/186644366/557124869-23d1681e-4a64-4e9d-af31-588e5e0ce2e7.mp4?jwt=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3NzI1NjIzODEsIm5iZiI6MTc3MjU2MjA4MSwicGF0aCI6Ii8xODY2NDQzNjYvNTU3MTI0ODY5LTIzZDE2ODFlLTRhNjQtNGU5ZC1hZjMxLTU4OGU1ZTBjZTJlNy5tcDQ_WC1BbXotQWxnb3JpdGhtPUFXUzQtSE1BQy1TSEEyNTYmWC1BbXotQ3JlZGVudGlhbD1BS0lBVkNPRFlMU0E1M1BRSzRaQSUyRjIwMjYwMzAzJTJGdXMtZWFzdC0xJTJGczMlMkZhd3M0X3JlcXVlc3QmWC1BbXotRGF0ZT0yMDI2MDMwM1QxODIxMjFaJlgtQW16LUV4cGlyZXM9MzAwJlgtQW16LVNpZ25hdHVyZT00NDM2NTZkYWRhOTRiNjY0YTJjYTkzZDVmNWIxODllMmZlMTExN2YzZGUyZjkyZjEyZGZiNTFjMThhNGM5OGNmJlgtQW16LVNpZ25lZEhlYWRlcnM9aG9zdCJ9.pAhZp5oQkURJkuhoAiX0JsRdlEGcONexJ3dVjGaT9zw