### PR TITLE
Auto-hide home indicator during fullscreen player on iOS 18 or lower

### DIFF
--- a/src/navigation/AppNavigator.tsx
+++ b/src/navigation/AppNavigator.tsx
@@ -1360,6 +1360,7 @@ const InnerNavigator = ({ initialRouteName }: { initialRouteName?: keyof RootSta
                 contentStyle: {
                   backgroundColor: '#000000', // Pure black for video player
                 },
+                autoHideHomeIndicator: true,
                 // iPad-specific fullscreen options
                 statusBarHidden: true,
                 statusBarAnimation: 'none',


### PR DESCRIPTION
Set the home indicator to prefer being hidden (default: false)

## Summary

Set the home indicator to prefer being hidden (default: false)

## PR type

- Bug fix

## Why

The iOS home indicator (bottom bar) stays permanently visible during video playback on iOS 18 devices. On iOS 26 it auto-hides natively, but iOS 18 and below require explicit opt-in via screen options.

## Policy check

<!-- Confirm these before requesting review -->
- [x] This PR is not cosmetic only.
- [x] This PR does not add a new major feature without prior approval.
- [x] This PR is small in scope and focused on one problem.
- [x] If this is a larger or directional change, I linked the issue where it was approved.

<!-- PRs that do not match this policy will usually be closed without merge. -->

## Testing

<!-- What you tested and how (manual + automated). -->
I don't have access to a Mac or Apple Developer account, so I was unable to build and test this change on a physical device. 

The fix is based on the documented `autoHideHomeIndicator` option from `@react-navigation/native-stack`, which is the standard way to set `prefersHomeIndicatorAutoHidden` on iOS. The change is minimal and low-risk — in the worst case it simply has no effect.