### PR TITLE
Fix typo in Italian locale for account management

### DIFF
--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -794,7 +794,7 @@
                 "description": "Aggiorna dal cloud (pull) o usa le impostazioni di questo dispositivo come sorgente principale (push).",
                 "pull_btn": "Pull dal Cloud",
                 "push_btn": "Push dal Dispositivo",
-                "manage_account": "Gestiscci Account",
+                "manage_account": "Gestisci Account",
                 "sign_out": "Disconnetti",
                 "sign_in_up": "Accedi / Registrati"
             },


### PR DESCRIPTION
## Summary

Corrected a spelling error in the Italian translation: changed "Gestiscci Account" to "Gestisci Account" (Italian for "Manage Account").

The previous version had an extra "c" which is grammatically incorrect in Italian.

## PR type

<!-- Pick one and delete the others -->
- Small maintenance improvement

## Why

Corrected a spelling error to improve the UI quality.

## Policy check

<!-- Confirm these before requesting review -->
- [x] This PR is not cosmetic only.
- [x] This PR does not add a new major feature without prior approval.
- [x] This PR is small in scope and focused on one problem.
- [ ] If this is a larger or directional change, I linked the issue where it was approved.

<!-- PRs that do not match this policy will usually be closed without merge. -->

## Testing

<!-- What you tested and how (manual + automated). -->
- [ ] iOS tested
- [x] Android tested

## Screenshots / Video (UI changes only)

N/A

## Breaking changes

None

## Linked issues

None
