### PR TITLE
MDBList settings screen visual bug fix

### DIFF
--- a/src/screens/MDBListSettingsScreen.tsx
+++ b/src/screens/MDBListSettingsScreen.tsx
@@ -700,7 +700,8 @@ const MDBListSettingsScreen: React.FC = () => {
             />
           </View>
         </View>
-
+ {isMdbListEnabled && 
+        <>
         <View style={[styles.card, !isMdbListEnabled && styles.disabledCard]}>
           <Text style={[styles.sectionTitle, { color: isDarkMode ? currentTheme.colors.mediumEmphasis : currentTheme.colors.textMutedDark }]}>
             {t('mdblist.api_section')}
@@ -885,6 +886,7 @@ const MDBListSettingsScreen: React.FC = () => {
             </Text>
           </TouchableOpacity>
         </View>
+        </>}
       </ScrollView>
       <CustomAlert
         visible={alertVisible}


### PR DESCRIPTION
## Summary

I have changed how API Key and Provider components are rendered. Now only if MDBList toggle is active the component will be rendered.

## PR type

- Bug fix

## Why

Visual Bug 

## Policy check

- [x] This PR is not cosmetic only.
- [x] This PR does not add a new major feature without prior approval.
- [x] This PR is small in scope and focused on one problem.
- [x] If this is a larger or directional change, I linked the issue where it was approved.

## Testing

- [ ] iOS tested
- [x ] Android tested

## Screenshots / Video (UI changes only)

Before my fix : 
<img width="384" height="865" alt="before_fix" src="https://github.com/user-attachments/assets/de63ba93-90d3-495b-9275-96d28a7d4a19" />

After my fix :  
<img width="388" height="862" alt="after_fix" src="https://github.com/user-attachments/assets/7734beae-8fc7-46f9-b3b2-23ec22f7d88b" />
<img width="372" height="835" alt="after_fix_2" src="https://github.com/user-attachments/assets/01d84041-48f6-4295-a38b-64794d44abbd" />


## Breaking changes

None

## Linked issues

None