### PR TITLE
feat: display custom season posters when TMDB enrichment fails

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
           cache: 'npm'
           
       - name: Install dependencies
-        run: npm ci
+        run: npm install --legacy-peer-deps
         
       - name: Build app
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
           cache: 'npm'
           
       - name: Install dependencies
-        run: npm install --legacy-peer-deps
+        run: npm ci
         
       - name: Build app
         run: |

--- a/src/components/metadata/SeriesContent.tsx
+++ b/src/components/metadata/SeriesContent.tsx
@@ -49,8 +49,8 @@ interface SeriesContentProps {
     mal_id?: number;
     external_ids?: {
       mal_id?: number;
-      seasons?: Array<{ season: number; poster?: string; }>;
     }
+    seasons?: Array<{ season: number; poster?: string; }>;
   };
   imdbId?: string; // IMDb ID for Trakt sync
 }

--- a/src/components/metadata/SeriesContent.tsx
+++ b/src/components/metadata/SeriesContent.tsx
@@ -49,6 +49,7 @@ interface SeriesContentProps {
     mal_id?: number;
     external_ids?: {
       mal_id?: number;
+      seasons?: Array<{ season: number; poster?: string; }>;
     }
   };
   imdbId?: string; // IMDb ID for Trakt sync
@@ -839,7 +840,7 @@ const SeriesContentComponent: React.FC<SeriesContentProps> = ({
     );
   }
 
-  const renderSeasonSelector = () => {
+  const  = () => {
     // Show selector if we have grouped episodes data or can derive from episodes
     if (!groupedEpisodes || Object.keys(groupedEpisodes).length <= 1) {
       return null;
@@ -929,11 +930,24 @@ const SeriesContentComponent: React.FC<SeriesContentProps> = ({
 
             // Get season poster URL (needed for both views)
             let seasonPoster = DEFAULT_PLACEHOLDER;
+            // 1. Highest Priority: TMDB poster via episode data
             if (seasonEpisodes[0]?.season_poster_path) {
               const tmdbUrl = tmdbService.getImageUrl(seasonEpisodes[0].season_poster_path, 'original');
-              if (tmdbUrl) seasonPoster = tmdbUrl;
-            } else if (metadata?.poster) {
-              seasonPoster = metadata.poster;
+              if (tmdbUrl) {
+                seasonPoster = tmdbUrl;
+              }
+            }
+            // If TMDB didn't return a valid poster, check priorities 2 and 3
+            if (seasonPoster === DEFAULT_PLACEHOLDER) {
+              // Try to find a custom poster matching the current season number
+              const customSeasonPoster = metadata?.seasons?.find(s => s.season === season)?.poster;
+              if (customSeasonPoster) {
+                // 2. Secondary Priority: Custom Addon Poster
+                seasonPoster = customSeasonPoster;
+              } else if (metadata?.poster) {
+                // 3. Fallback Priority: Main Series Poster
+                seasonPoster = metadata.poster;
+              }
             }
 
             if (seasonViewMode === 'text') {

--- a/src/components/metadata/SeriesContent.tsx
+++ b/src/components/metadata/SeriesContent.tsx
@@ -840,7 +840,7 @@ const SeriesContentComponent: React.FC<SeriesContentProps> = ({
     );
   }
 
-  const  = () => {
+  const renderSeasonSelector = () => {
     // Show selector if we have grouped episodes data or can derive from episodes
     if (!groupedEpisodes || Object.keys(groupedEpisodes).length <= 1) {
       return null;

--- a/src/services/catalog/content-mappers.ts
+++ b/src/services/catalog/content-mappers.ts
@@ -104,6 +104,10 @@ export function convertMetaToStreamingContentEnhanced(
   if ((meta as any).videos) {
     converted.videos = (meta as any).videos;
   }
+  // CUSTOM CATALOG POSTERS
+  if ((meta as any).seasons) {
+    converted.seasons = (meta as any).seasons;
+  }
 
   return converted;
 }

--- a/src/services/catalog/types.ts
+++ b/src/services/catalog/types.ts
@@ -56,6 +56,10 @@ export interface StreamingContent {
   released?: string;
   trailerStreams?: any[];
   videos?: any[];
+  seasons?: Array<{
+    season: number;
+    poster?: string;
+  }>;
   inLibrary?: boolean;
   directors?: string[];
   creators?: string[];


### PR DESCRIPTION
## Summary

This PR adds a fallback logic to the Stremio parser and Season Picker UI to support custom season posters. 

Specifically:
1. Added `seasons` to the `StreamingContent` interface in `types.ts`.
2. Updated `content-mappers.ts` to pass the `seasons` array from the raw Stremio `meta` object.
3. Updated `renderSeasonSelector` in `SeriesContent.tsx` to prioritize: TMDB image -> Custom Addon Season Poster -> Main Series Poster.

## PR type

- Small maintenance improvement

## Why

When a Stremio addon uses a custom catalog (such as One Pace, fan edits, sports, or YouTube channels) that lacks a standard TMDB ID, Nuvio falls back to duplicating the main show poster for every single season in the Season Picker UI. 

This change allows addon developers to pass a custom `seasons` array (e.g., `seasons: [{ season: 1, poster: "URL" }]`) in their `meta` response, allowing the app to display beautiful, unique season posters even when TMDB enrichment fails or is bypassed.

## Policy check

- [x] This PR is not cosmetic only.
- [x] This PR does not add a new major feature without prior approval.
- [x] This PR is small in scope and focused on one problem.
- [ ] If this is a larger or directional change, I linked the issue where it was approved.

## Testing

- [ ] iOS tested
- [ ] Android tested

*Note for maintainers: I was unable to successfully compile the Android environment locally on my Windows machine due to persistent Gradle/Kotlin JVM target conflicts. I have written and verified the TypeScript/React logic, but I am submitting this PR so someone with a working build environment can test and verify it on a device.*

## Screenshots / Video (UI changes only)

N/A - Unable to capture screenshots due to local build environment constraints. 

## Breaking changes

None

## Linked issues

Fixes #676 