### PR TITLE
Added tip for error message

### DIFF
--- a/src/components/CustomAlert.tsx
+++ b/src/components/CustomAlert.tsx
@@ -21,6 +21,7 @@ interface CustomAlertProps {
   visible: boolean;
   title: string;
   message: string;
+  subtitle?: string;
   onClose: () => void;
   actions?: Array<{
     label: string;
@@ -33,6 +34,7 @@ export const CustomAlert = ({
   visible,
   title,
   message,
+  subtitle,
   onClose,
   actions = [
     { label: 'OK', onPress: onClose }
@@ -109,6 +111,13 @@ export const CustomAlert = ({
               <Text style={styles.message}>
                 {message}
               </Text>
+
+              {/* Subtitle / tooltip */}
+              {subtitle ? (
+                <Text style={styles.subtitle}>
+                  {subtitle}
+                </Text>
+              ) : null}
 
               {/* Actions */}
               <View style={[
@@ -200,9 +209,17 @@ const styles = StyleSheet.create({
   message: {
     color: '#AAAAAA',
     fontSize: 15,
-    marginBottom: 24,
+    marginBottom: 8,
     textAlign: 'center',
     lineHeight: 22,
+    letterSpacing: 0.1,
+  },
+  subtitle: {
+    color: '#666666',
+    fontSize: 12,
+    marginBottom: 24,
+    textAlign: 'center',
+    lineHeight: 18,
     letterSpacing: 0.1,
   },
   actionsRow: {

--- a/src/screens/streams/StreamsScreen.tsx
+++ b/src/screens/streams/StreamsScreen.tsx
@@ -35,6 +35,7 @@ export const StreamsScreen = () => {
     alertVisible,
     alertTitle,
     alertMessage,
+    alertSubtitle,
     alertActions,
     openAlert,
     closeAlert,
@@ -206,6 +207,7 @@ export const StreamsScreen = () => {
           visible={alertVisible}
           title={alertTitle}
           message={alertMessage}
+          subtitle={alertSubtitle}
           actions={alertActions}
           onClose={closeAlert}
         />

--- a/src/screens/streams/useStreamsScreen.ts
+++ b/src/screens/streams/useStreamsScreen.ts
@@ -68,6 +68,7 @@ export const useStreamsScreen = () => {
   const [alertVisible, setAlertVisible] = useState(false);
   const [alertTitle, setAlertTitle] = useState('');
   const [alertMessage, setAlertMessage] = useState('');
+  const [alertSubtitle, setAlertSubtitle] = useState('');
   const [alertActions, setAlertActions] = useState<AlertAction[]>([]);
 
   // Loading and provider state
@@ -174,12 +175,13 @@ export const useStreamsScreen = () => {
 
   // Open alert helper
   const openAlert = useCallback(
-    (title: string, message: string, actions?: AlertAction[]) => {
+    (title: string, message: string, actions?: AlertAction[], subtitle?: string) => {
       if (!isMounted.current) return;
 
       try {
         setAlertTitle(title);
         setAlertMessage(message);
+        setAlertSubtitle(subtitle ?? '');
         setAlertActions(actions && actions.length > 0 ? actions : [{ label: 'OK', onPress: () => { } }]);
         setAlertVisible(true);
       } catch (error) {
@@ -465,7 +467,7 @@ export const useStreamsScreen = () => {
 
         // Block magnet links
         if (typeof stream.url === 'string' && stream.url.startsWith('magnet:')) {
-          openAlert('Not supported', 'Torrent streaming is not supported yet.');
+          openAlert('Not supported', 'Torrent streaming is not supported yet.', undefined, 'You need a Debrid provider.');
           return;
         }
 
@@ -1145,6 +1147,7 @@ export const useStreamsScreen = () => {
     alertVisible,
     alertTitle,
     alertMessage,
+    alertSubtitle,
     alertActions,
     openAlert,
     closeAlert,


### PR DESCRIPTION
Adds an optional `subtitle` prop to `CustomAlert` and uses it to display a `'You need a Debrid provider.'` hint below the message when a user tries to play a magnet/torrent link directly.

## Summary

Adds an optional `subtitle` prop to `CustomAlert` and uses it to display a `'You need a Debrid provider.'` hint below the message when a user tries to play a magnet/torrent link directly.

## PR type

<!-- Pick one and delete the others -->
- Small maintenance improvement

## Why

When a user taps a torrent stream without a Debrid provider configured, the alert said "Torrent streaming is not supported yet." with no further context. Users had no indication of what they need to do. The subtitle makes the requirement immediately clear.

## Policy check

<!-- Confirm these before requesting review -->
- [x] This PR is not cosmetic only.
- [x] This PR does not add a new major feature without prior approval.
- [x] This PR is small in scope and focused on one problem.

<!-- PRs that do not match this policy will usually be closed without merge. -->

## Testing

<!-- What you tested and how (manual + automated). -->
- [ ] iOS tested
- [x] Android tested

Manually triggered the alert by tapping a magnet-link stream without a Debrid provider. Verified the subtitle `'You need a Debrid provider.'` appears below the main message in the alert dialog.

## Screenshots / Video (UI changes only)

<img width="1080" height="2400" alt="Preview20260328_125300" src="https://github.com/user-attachments/assets/dd782717-7a80-4131-82a1-f9d117eb4212" />


## Breaking changes

None

## Linked issues

None
