### PR TITLE
feat: IMDb scores clickable to IMDb page

### DIFF
--- a/src/components/metadata/MetadataDetails.tsx
+++ b/src/components/metadata/MetadataDetails.tsx
@@ -6,6 +6,7 @@ import {
   TouchableOpacity,
   ActivityIndicator,
   Dimensions,
+  Linking,
 } from 'react-native';
 import { MaterialIcons } from '@expo/vector-icons';
 import FastImage from '@d11/react-native-fast-image';
@@ -240,7 +241,11 @@ const MetadataDetails: React.FC<MetadataDetailsProps> = ({
           <AgeRatingBadge rating={metadata.certification} />
         )}
         {metadata.imdbRating && !isMDBEnabled && (
-          <View style={styles.ratingContainer}>
+          <TouchableOpacity
+            style={styles.ratingContainer}
+            activeOpacity={0.7}
+            onPress={() => _imdbId && Linking.openURL(`https://www.imdb.com/title/${_imdbId}/`)}
+          >
             <FastImage
               source={{ uri: IMDb_LOGO }}
               style={[
@@ -259,7 +264,7 @@ const MetadataDetails: React.FC<MetadataDetailsProps> = ({
                 fontSize: isTV ? 18 : isLargeTablet ? 17 : isTablet ? 16 : 15
               }
             ]}>{metadata.imdbRating}</Text>
-          </View>
+          </TouchableOpacity>
         )}
       </View>
 

--- a/src/components/metadata/RatingsSection.tsx
+++ b/src/components/metadata/RatingsSection.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState, useRef, useCallback, useMemo } from 'react';
-import { View, Text, StyleSheet, ActivityIndicator, Image, Animated, Dimensions } from 'react-native';
+import { View, Text, StyleSheet, ActivityIndicator, Image, Animated, Dimensions, Linking, TouchableOpacity } from 'react-native';
 import { MaterialIcons as MaterialIconsWrapper } from '@expo/vector-icons';
 import { useTheme } from '../../contexts/ThemeContext';
 import FastImage from '@d11/react-native-fast-image';
@@ -262,9 +262,10 @@ export const RatingsSection: React.FC<RatingsSectionProps> = ({ imdbId, type }) 
         {displayRatings.map(([source, value]) => {
           const config = ratingConfig[source as keyof typeof ratingConfig];
           const displayValue = config.transform(parseFloat(value as string));
+          const isIMDb = source === 'imdb';
 
-          return (
-            <View key={source} style={[styles.compactRatingItem, { marginRight: itemSpacing }]}>
+          const Content = (
+            <View style={[styles.compactRatingItem, { marginRight: itemSpacing }]}>
               {config.isImage ? (
                 <FastImage
                   source={config.icon as any}
@@ -298,6 +299,20 @@ export const RatingsSection: React.FC<RatingsSectionProps> = ({ imdbId, type }) 
               </Text>
             </View>
           );
+
+          if (isIMDb) {
+            return (
+              <TouchableOpacity
+                key={source}
+                activeOpacity={0.7}
+                onPress={() => Linking.openURL(`https://www.imdb.com/title/${imdbId}/`)}
+              >
+                {Content}
+              </TouchableOpacity>
+            );
+          }
+
+          return React.cloneElement(Content, { key: source });
         })}
       </View>
     </Animated.View>


### PR DESCRIPTION
## Summary

Made the IMDb logo and rating clickable when viewing a title's metadata, so it opens the relevant IMDb page.

## PR type

- Small maintenance improvement

## Why

A nice natural instinct improvement to the app. 

## Policy check

<!-- Confirm these before requesting review -->
- [Y] This PR is not cosmetic only.
- [Y] This PR does not add a new major feature without prior approval.
- [Y] This PR is small in scope and focused on one problem.
- [Y] If this is a larger or directional change, I linked the issue where it was approved.


## Testing

Whilst I have not tested myself, the code makes sense and similar approach in my own app works.

## Screenshots / Video (UI changes only)

No UI visible changes 

## Breaking changes

None

## Linked issues

Implements: https://github.com/NuvioMedia/NuvioMobile/issues/737
