### PR TITLE
fix: align episode streams modal provider sorting with streams screen

### DIFF
--- a/src/components/player/AndroidVideoPlayer.tsx
+++ b/src/components/player/AndroidVideoPlayer.tsx
@@ -188,7 +188,7 @@ const AndroidVideoPlayer: React.FC = () => {
   }, [uri, episodeId]);
 
   const metadataResult = useMetadata({ id: id || 'placeholder', type: (type as any) });
-  const { metadata, cast } = Boolean(id && type) ? (metadataResult as any) : { metadata: null, cast: [] };
+  const { metadata, cast, addonResponseOrder } = Boolean(id && type) ? (metadataResult as any) : { metadata: null, cast: [] };
 
   // For content with provider IDs (e.g. kitsu:123), imdbId from route params may be null at
   // navigation time. useMetadata resolves it asynchronously via ARM + TMDB. Use that resolved
@@ -752,7 +752,7 @@ const AndroidVideoPlayer: React.FC = () => {
   // Subtitle addon fetching
   const fetchAvailableSubtitles = useCallback(async () => {
     const targetImdbId = resolvedImdbId;
-    
+
     setIsLoadingSubtitleList(true);
     try {
       const stremioType = type === 'series' ? 'series' : 'movie';
@@ -783,7 +783,7 @@ const AndroidVideoPlayer: React.FC = () => {
       const pluginPromise = (async () => {
         try {
           let tmdbIdStr: string | null = null;
-          
+
           // Try to resolve TMDB ID
           if (id && id.startsWith('tmdb:')) {
             tmdbIdStr = id.split(':')[1];
@@ -799,7 +799,7 @@ const AndroidVideoPlayer: React.FC = () => {
               season,
               episode
             );
-            
+
             return results.map((sub: any) => ({
               id: sub.url, // Use URL as ID for simple deduplication
               url: sub.url,
@@ -824,7 +824,7 @@ const AndroidVideoPlayer: React.FC = () => {
 
       setAvailableSubtitles(allSubs);
       logger.info(`[AndroidVideoPlayer] Fetched ${allSubs.length} subtitles (${stremioSubs.length} Stremio, ${pluginSubs.length} Plugins)`);
-      
+
     } catch (e) {
       logger.error('[AndroidVideoPlayer] Error in fetchAvailableSubtitles', e);
     } finally {
@@ -1347,6 +1347,7 @@ const AndroidVideoPlayer: React.FC = () => {
         episode={modals.selectedEpisodeForStreams}
         onSelectStream={handleEpisodeStreamSelect}
         metadata={{ id: id, name: title }}
+        addonResponseOrder={addonResponseOrder}
       />
 
       {/* MPV Switch Confirmation Alert */}

--- a/src/components/player/KSPlayerCore.tsx
+++ b/src/components/player/KSPlayerCore.tsx
@@ -160,7 +160,7 @@ const KSPlayerCore: React.FC = () => {
   const speedControl = useSpeedControl(1.0);
 
   // Metadata Hook
-  const { metadata, groupedEpisodes, cast } = useMetadata({ id, type: type as 'movie' | 'series' });
+  const { metadata, groupedEpisodes, cast, addonResponseOrder } = useMetadata({ id, type: type as 'movie' | 'series' });
 
   // Trakt Autosync
   const traktAutosync = useTraktAutosync({
@@ -365,7 +365,7 @@ const KSPlayerCore: React.FC = () => {
   // Subtitle Fetching Logic
   const fetchAvailableSubtitles = async (imdbIdParam?: string, autoSelectEnglish = true) => {
     const targetImdbId = imdbIdParam || imdbId;
-    
+
     customSubs.setIsLoadingSubtitleList(true);
     try {
       const stremioType = type === 'series' ? 'series' : 'movie';
@@ -396,7 +396,7 @@ const KSPlayerCore: React.FC = () => {
       const pluginPromise = (async () => {
         try {
           let tmdbIdStr: string | null = null;
-          
+
           if (id && id.startsWith('tmdb:')) {
             tmdbIdStr = id.split(':')[1];
           } else if (targetImdbId) {
@@ -411,7 +411,7 @@ const KSPlayerCore: React.FC = () => {
               season,
               episode
             );
-            
+
             return results.map((sub: any) => ({
               id: sub.url,
               url: sub.url,
@@ -436,7 +436,7 @@ const KSPlayerCore: React.FC = () => {
 
       customSubs.setAvailableSubtitles(allSubs);
       logger.info(`[KSPlayerCore] Fetched ${allSubs.length} subtitles (${stremioSubs.length} Stremio, ${pluginSubs.length} Plugins)`);
-      
+
     } catch (error) {
       logger.error('[KSPlayerCore] Error in fetchAvailableSubtitles', error);
     } finally {
@@ -1197,6 +1197,7 @@ const KSPlayerCore: React.FC = () => {
         episode={modals.selectedEpisodeForStreams}
         onSelectStream={handleEpisodeStreamSelect}
         metadata={{ id: id, name: title }}
+        addonResponseOrder={addonResponseOrder}
       />
     </View>
   );

--- a/src/components/player/modals/EpisodeStreamsModal.tsx
+++ b/src/components/player/modals/EpisodeStreamsModal.tsx
@@ -19,6 +19,7 @@ interface EpisodeStreamsModalProps {
   onClose: () => void;
   onSelectStream: (stream: Stream) => void;
   metadata?: { id?: string; name?: string };
+  addonResponseOrder?: string[];
 }
 
 const QualityBadge = ({ quality }: { quality: string | null | undefined }) => {
@@ -58,6 +59,7 @@ export const EpisodeStreamsModal: React.FC<EpisodeStreamsModalProps> = ({
   onClose,
   onSelectStream,
   metadata,
+  addonResponseOrder,
 }) => {
   const { t } = useTranslation();
   const { width } = useWindowDimensions();
@@ -139,7 +141,44 @@ export const EpisodeStreamsModal: React.FC<EpisodeStreamsModalProps> = ({
 
   if (!visible) return null;
 
-  const sortedProviders = Object.entries(availableStreams);
+  const installedAddons = stremioService.getInstalledAddons();
+  const sortedProviders = Object.entries(availableStreams).sort(
+    ([keyA], [keyB]) => {
+      const isAddonA = installedAddons.some(
+        (addon) => addon.installationId === keyA || addon.id === keyA,
+      );
+      const isAddonB = installedAddons.some(
+        (addon) => addon.installationId === keyB || addon.id === keyB,
+      );
+
+      // Addons always come before plugins
+      if (isAddonA && !isAddonB) return -1;
+      if (!isAddonA && isAddonB) return 1;
+
+      // Both are addons - sort by installation order
+      if (isAddonA && isAddonB) {
+        const indexA = installedAddons.findIndex(
+          (addon) => addon.installationId === keyA || addon.id === keyA,
+        );
+        const indexB = installedAddons.findIndex(
+          (addon) => addon.installationId === keyB || addon.id === keyB,
+        );
+        return indexA - indexB;
+      }
+
+      // Both are plugins - sort by response order
+      if (addonResponseOrder) {
+        const responseIndexA = addonResponseOrder.indexOf(keyA);
+        const responseIndexB = addonResponseOrder.indexOf(keyB);
+        if (responseIndexA !== -1 && responseIndexB !== -1)
+          return responseIndexA - responseIndexB;
+        if (responseIndexA !== -1) return -1;
+        if (responseIndexB !== -1) return 1;
+      }
+      return 0;
+    },
+  );
+
 
   return (
     <View style={[StyleSheet.absoluteFill, { zIndex: 10000 }]}>


### PR DESCRIPTION
## Summary

  Align episode stream provider ordering in the player modal with the main Streams screen logic.

  EpisodeStreamsModal now sorts providers using the same rules as useStreamsScreen:

  - Installed addons first, in installation order
  - Plugin providers after addons, ordered by addonResponseOrder (response order)

  Also passes addonResponseOrder from both player implementations into the modal
  (AndroidVideoPlayer and KSPlayerCore) so sorting is consistent on both platforms.

  ## PR type

  - Bug fix

  ## Why

  Provider ordering in the episode streams modal could differ from the main Streams screen,
  which caused inconsistent source ordering for the same content.
  This change makes provider ordering consistent across both entry points.

  ## Policy check

  - [x] This PR is not cosmetic only.
  - [x] This PR does not add a new major feature without prior approval.
  - [x] This PR is small in scope and focused on one problem.
  - [x] If this is a larger or directional change, I linked the issue where it was approved.

  ## Testing

  - [ ] iOS tested
  - [x] Android tested

  Manual testing:

  - Open episodic content in player
  - Open Episode Streams modal
  - Verify installed addons appear first in installation order
  - Verify plugin providers are ordered by response order
  - Verify ordering matches Streams screen behavior

  Automated:

  - npx tsc --noEmit passed

  ## Screenshots / Video (UI changes only)

  None (behavioral/sorting fix only)

  ## Breaking changes

  None

  ## Linked issues

  N/A