### PR TITLE
Ensure series streams use parentId:season:episode format in requests

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerStreamsRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerStreamsRepository.kt
@@ -151,6 +151,23 @@ object PlayerStreamsRepository {
             return
         }
 
+        // For series episodes the Stremio protocol requires the id in the request URL to
+        // be "parentId:season:episode" (e.g. tt1234567:1:2). Append if missing.
+        val effectiveAddonVideoId = if (type == "series" && season != null && episode != null) {
+            val suffix = ":$season:$episode"
+            if (videoId.endsWith(suffix)) videoId else "$videoId$suffix"
+        } else {
+            videoId
+        }
+
+        // Strip the suffix when checking idPrefixes so addons with prefix "tt" still match
+        // when effectiveAddonVideoId is "tt1234567:1:2".
+        val baseVideoIdForPrefixCheck = if (season != null && episode != null) {
+            effectiveAddonVideoId.removeSuffix(":$season:$episode")
+        } else {
+            effectiveAddonVideoId
+        }
+
         val installedAddons = AddonRepository.uiState.value.addons
         val pluginScrapers = if (AppFeaturePolicy.pluginsEnabled) {
             PluginRepository.initialize()
@@ -174,7 +191,10 @@ object PlayerStreamsRepository {
                     resource.name == "stream" &&
                         resource.types.contains(type) &&
                         (resource.idPrefixes.isEmpty() ||
-                            resource.idPrefixes.any { videoId.startsWith(it) })
+                            resource.idPrefixes.any { prefix ->
+                                effectiveAddonVideoId.startsWith(prefix) ||
+                                    baseVideoIdForPrefixCheck.startsWith(prefix)
+                            })
                 }
                 if (!supportsRequestedStream) return@mapNotNull null
 
@@ -221,7 +241,7 @@ object PlayerStreamsRepository {
                         manifestUrl = addon.manifest.transportUrl,
                         resource = "stream",
                         type = type,
-                        id = videoId,
+                        id = effectiveAddonVideoId,
                     )
 
                     val displayName = addon.addonName

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/streams/StreamsRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/streams/StreamsRepository.kt
@@ -93,6 +93,18 @@ object StreamsRepository {
             )
         }
 
+        // For series episodes the Stremio protocol requires the id in the request URL to
+        // be "parentId:season:episode" (e.g. tt1234567:1:2). If the videoId coming from
+        // the addon meta doesn't already carry the suffix, append it here so that every
+        // addon gets a correctly-formed stream request.
+        val effectiveAddonVideoId = if (type == "series" && season != null && episode != null) {
+            val suffix = ":$season:$episode"
+            if (videoId.endsWith(suffix)) videoId else "$videoId$suffix"
+        } else {
+            videoId
+        }
+        log.d { "Effective addon videoId: $effectiveAddonVideoId (original: $videoId, season=$season, episode=$episode)" }
+
         val embeddedStreams = MetaDetailsRepository.findEmbeddedStreams(videoId)
         if (embeddedStreams.isNotEmpty()) {
             log.d { "Using ${embeddedStreams.size} embedded streams for type=$type id=$videoId" }
@@ -129,6 +141,15 @@ object StreamsRepository {
             return
         }
 
+        // When checking idPrefixes, also test the bare parent ID (without :season:episode)
+        // so that addons with idPrefixes=["tt"] still match when effectiveAddonVideoId is
+        // "tt1234567:1:2".
+        val baseVideoIdForPrefixCheck = if (season != null && episode != null) {
+            effectiveAddonVideoId.removeSuffix(":$season:$episode")
+        } else {
+            effectiveAddonVideoId
+        }
+
         val streamAddons = installedAddons
             .mapNotNull { addon ->
                 val manifest = addon.manifest ?: return@mapNotNull null
@@ -136,7 +157,10 @@ object StreamsRepository {
                     resource.name == "stream" &&
                         resource.types.contains(type) &&
                         (resource.idPrefixes.isEmpty() ||
-                            resource.idPrefixes.any { videoId.startsWith(it) })
+                            resource.idPrefixes.any { prefix ->
+                                effectiveAddonVideoId.startsWith(prefix) ||
+                                    baseVideoIdForPrefixCheck.startsWith(prefix)
+                            })
                 }
                 if (!supportsRequestedStream) return@mapNotNull null
 
@@ -147,7 +171,7 @@ object StreamsRepository {
                 )
             }
 
-        log.d { "Found ${streamAddons.size} addons for stream type=$type id=$videoId" }
+        log.d { "Found ${streamAddons.size} addons for stream type=$type effectiveId=$effectiveAddonVideoId" }
 
             if (streamAddons.isEmpty() && pluginProviderGroups.isEmpty()) {
             _uiState.value = StreamsUiState(
@@ -243,7 +267,7 @@ object StreamsRepository {
                         manifestUrl = addon.manifest.transportUrl,
                         resource = "stream",
                         type = type,
-                        id = videoId,
+                        id = effectiveAddonVideoId,
                     )
                     log.d { "Fetching streams from: $url" }
 


### PR DESCRIPTION
## Summary

Ensure that series stream requests consistently use the `parentId:season:episode` format.

## PR type

- Bug fix

## Why

Previously, inconsistent formatting could lead to incorrect or failed stream retrieval for series. This change ensures uniform request structure, reducing errors and improving reliability.

## Policy check

* [x] This PR is not cosmetic-only, unless it is a translation PR.
* [x] This PR does not add a new major feature without prior approval.
* [x] This PR is small in scope and focused on one problem.

## Testing

- Verified correct stream loading for multiple series, seasons, and episodes

- Tested edge cases with different parentId, season, and episode values

## Breaking changes

None

## Linked issues

Fixes #795, #808