### PR TITLE
Hide speed indicator after 2s to reduce visual clutter during hold-to-speed gesture

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,12 @@
+[submodule "MPVKit"]
+	path = MPVKit
+	url = https://github.com/tapframe/MPVNuvio.git
+[submodule "libass-android"]
+	path = libass-android
+	url = https://github.com/peerless2012/libass-android.git
+[submodule "mediamp"]
+	path = mediamp
+	url = https://github.com/tapframe/mediampnuvio.git
+[submodule "vendor/mpv-kt-upstream"]
+	path = vendor/mpv-kt-upstream
+	url = https://github.com/zt64/mpv-kt.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -7,6 +7,3 @@
 [submodule "mediamp"]
 	path = mediamp
 	url = https://github.com/tapframe/mediampnuvio.git
-[submodule "vendor/mpv-kt-upstream"]
-	path = vendor/mpv-kt-upstream
-	url = https://github.com/zt64/mpv-kt.git

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerScreen.kt
@@ -79,10 +79,10 @@ private val PlayerActionRowHeight = 50.dp
 
 private fun sliderOverlayBottomPadding(metrics: PlayerLayoutMetrics) =
     metrics.sliderBottomOffset +
-        metrics.sliderTouchHeight +
-        PlayerTimeRowHeight +
-        PlayerActionRowHeight +
-        PlayerSliderOverlayGap
+            metrics.sliderTouchHeight +
+            PlayerTimeRowHeight +
+            PlayerActionRowHeight +
+            PlayerSliderOverlayGap
 
 private enum class PlayerSideGesture {
     Brightness,
@@ -195,6 +195,7 @@ fun PlayerScreen(
         var gestureMessageJob by remember { mutableStateOf<Job?>(null) }
         var accumulatedSeekResetJob by remember { mutableStateOf<Job?>(null) }
         var accumulatedSeekState by remember { mutableStateOf<PlayerAccumulatedSeekState?>(null) }
+        var speedIndicatorJob by remember { mutableStateOf<Job?>(null) }
         var initialLoadCompleted by remember(activeSourceUrl) { mutableStateOf(false) }
         var speedBoostRestoreSpeed by remember(activeSourceUrl) { mutableStateOf<Float?>(null) }
         var isHoldToSpeedGestureActive by remember(activeSourceUrl) { mutableStateOf(false) }
@@ -202,7 +203,7 @@ fun PlayerScreen(
             val initialProgressFraction = activeInitialProgressFraction
             mutableStateOf(
                 activeInitialPositionMs <= 0L &&
-                    (initialProgressFraction == null || initialProgressFraction <= 0f),
+                        (initialProgressFraction == null || initialProgressFraction <= 0f),
             )
         }
         var lastProgressPersistEpochMs by remember(activeSourceUrl) { mutableStateOf(0L) }
@@ -680,9 +681,18 @@ fun PlayerScreen(
                 icon = GestureFeedbackIcon.Speed,
             )
             hapticFeedback.performHapticFeedback(HapticFeedbackType.LongPress)
+
+            // Hide the speed indicator after 2 seconds, but keep speed active
+            speedIndicatorJob?.cancel()
+            speedIndicatorJob = scope.launch {
+                delay(2_000L)
+                liveGestureFeedback = null
+            }
         }
 
         fun deactivateHoldToSpeed() {
+            speedIndicatorJob?.cancel()
+            speedIndicatorJob = null
             isHoldToSpeedGestureActive = false
             val restoreSpeed = speedBoostRestoreSpeed ?: return
             playerController?.setPlaybackSpeed(restoreSpeed)
@@ -910,10 +920,10 @@ fun PlayerScreen(
             val settings = playerSettingsUiState
             val shouldAutoSelectInManualMode =
                 settings.streamAutoPlayMode == StreamAutoPlayMode.MANUAL &&
-                    (
-                        settings.streamAutoPlayNextEpisodeEnabled ||
-                            settings.streamAutoPlayPreferBingeGroup
-                        )
+                        (
+                                settings.streamAutoPlayNextEpisodeEnabled ||
+                                        settings.streamAutoPlayPreferBingeGroup
+                                )
 
             // Determine auto-play mode for next episode
             val effectiveMode = if (shouldAutoSelectInManualMode) {
@@ -1387,8 +1397,8 @@ fun PlayerScreen(
                             if (gestureMode == null) {
                                 val horizontalDominant =
                                     !isHoldToSpeedGestureActiveState.value &&
-                                        abs(totalDx) > viewConfiguration.touchSlop &&
-                                        abs(totalDx) > abs(totalDy)
+                                            abs(totalDx) > viewConfiguration.touchSlop &&
+                                            abs(totalDx) > abs(totalDy)
                                 val verticalDominant =
                                     abs(totalDy) > viewConfiguration.touchSlop && abs(totalDy) > abs(totalDx)
 


### PR DESCRIPTION
## Summary
Modify the hold-to-speed gesture so the speed indicator overlay auto-hides after 2 seconds while the speed boost remains active until the finger is released.

## PR type
- Small maintenance improvement

## Why
The speed indicator previously stayed visible for the entire duration of a hold-to-speed gesture, which was visually distracting and obscured video content. The overlay is only informational — the user already knows the speed is active after the initial confirmation. Auto-hiding it after 2 seconds improves the viewing experience without removing any functionality.

## Policy check
- [x] This PR is not cosmetic-only, unless it is a translation PR.
- [x] This PR does not add a new major feature without prior approval.
- [x] This PR is small in scope and focused on one problem.
- [ ] If this is a larger or directional change, I linked the **approved** feature request issue below.

## Testing
Tested on Android.
- Manually verified: press and hold triggers speed boost + indicator appears immediately
- Indicator auto-hides after ~2 seconds; speed remains elevated
- Releasing finger restores original playback speed correctly
- Verified no race condition: releasing finger before 2s cancels the hide job cleanly
- Verified repeated hold/release cycles work correctly with no stale state

## Screenshots / Video (UI changes only)
None
<!-- Short clip recommended: show overlay appearing then fading while speed stays active -->

## Breaking changes
No breaking changes. Existing hold-to-speed behavior is preserved; only the overlay visibility timing is affected.

## Linked issues
<img width="807" height="726" alt="image" src="https://github.com/user-attachments/assets/8ea9e28a-c98a-4230-a0ab-e0d7fb5c7b4e" />
