### PR TITLE
Fix/language reset on restart

### DIFF
--- a/composeApp/src/androidMain/kotlin/com/nuvio/app/features/settings/ThemeSettingsStorage.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/nuvio/app/features/settings/ThemeSettingsStorage.android.kt
@@ -18,7 +18,8 @@ actual object ThemeSettingsStorage {
     private const val selectedThemeKey = "selected_theme"
     private const val amoledEnabledKey = "amoled_enabled"
     private const val selectedAppLanguageKey = "selected_app_language"
-    private val syncKeys = listOf(selectedThemeKey, amoledEnabledKey, selectedAppLanguageKey)
+    private val profileScopedSyncKeys = listOf(selectedThemeKey, amoledEnabledKey)
+    private val globalSyncKeys = listOf(selectedAppLanguageKey)
 
     private var preferences: SharedPreferences? = null
 
@@ -51,12 +52,12 @@ actual object ThemeSettingsStorage {
     }
 
     actual fun loadSelectedAppLanguage(): String? =
-        preferences?.getString(ProfileScopedKey.of(selectedAppLanguageKey), null)
+        preferences?.getString(selectedAppLanguageKey, null)
 
     actual fun saveSelectedAppLanguage(languageCode: String) {
         preferences
             ?.edit()
-            ?.putString(ProfileScopedKey.of(selectedAppLanguageKey), languageCode)
+            ?.putString(selectedAppLanguageKey, languageCode)
             ?.apply()
     }
 
@@ -74,7 +75,8 @@ actual object ThemeSettingsStorage {
 
     actual fun replaceFromSyncPayload(payload: JsonObject) {
         preferences?.edit()?.apply {
-            syncKeys.forEach { remove(ProfileScopedKey.of(it)) }
+            profileScopedSyncKeys.forEach { remove(ProfileScopedKey.of(it)) }
+            globalSyncKeys.forEach { remove(it) }
         }?.apply()
 
         payload.decodeSyncString(selectedThemeKey)?.let(::saveSelectedTheme)

--- a/composeApp/src/androidMain/kotlin/com/nuvio/app/features/settings/ThemeSettingsStorage.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/nuvio/app/features/settings/ThemeSettingsStorage.android.kt
@@ -51,8 +51,13 @@ actual object ThemeSettingsStorage {
             ?.apply()
     }
 
-    actual fun loadSelectedAppLanguage(): String? =
-        preferences?.getString(selectedAppLanguageKey, null)
+    actual fun loadSelectedAppLanguage(): String? {
+        val value = preferences?.getString(selectedAppLanguageKey, null)
+        if (value != null) return value
+        val legacy = preferences?.getString(ProfileScopedKey.of(selectedAppLanguageKey), null)
+        if (legacy != null) saveSelectedAppLanguage(legacy)
+        return legacy
+    }
 
     actual fun saveSelectedAppLanguage(languageCode: String) {
         preferences

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/profiles/ProfileRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/profiles/ProfileRepository.kt
@@ -70,6 +70,7 @@ object ProfileRepository {
         val stored = decodeStoredPayload() ?: return false
         loadedCacheForUserId = stored.userId
         applyStoredPayload(stored)
+        ThemeSettingsRepository.onProfileChanged()
         return _state.value.profiles.isNotEmpty()
     }
 

--- a/composeApp/src/iosMain/kotlin/com/nuvio/app/features/settings/ThemeSettingsStorage.ios.kt
+++ b/composeApp/src/iosMain/kotlin/com/nuvio/app/features/settings/ThemeSettingsStorage.ios.kt
@@ -14,7 +14,8 @@ actual object ThemeSettingsStorage {
     private const val selectedThemeKey = "selected_theme"
     private const val amoledEnabledKey = "amoled_enabled"
     private const val selectedAppLanguageKey = "selected_app_language"
-    private val syncKeys = listOf(selectedThemeKey, amoledEnabledKey, selectedAppLanguageKey)
+    private val profileScopedSyncKeys = listOf(selectedThemeKey, amoledEnabledKey)
+    private val globalSyncKeys = listOf(selectedAppLanguageKey)
 
     actual fun loadSelectedTheme(): String? =
         NSUserDefaults.standardUserDefaults.stringForKey(ProfileScopedKey.of(selectedThemeKey))
@@ -38,10 +39,10 @@ actual object ThemeSettingsStorage {
     }
 
     actual fun loadSelectedAppLanguage(): String? =
-        NSUserDefaults.standardUserDefaults.stringForKey(ProfileScopedKey.of(selectedAppLanguageKey))
+        NSUserDefaults.standardUserDefaults.stringForKey(selectedAppLanguageKey)
 
     actual fun saveSelectedAppLanguage(languageCode: String) {
-        NSUserDefaults.standardUserDefaults.setObject(languageCode, forKey = ProfileScopedKey.of(selectedAppLanguageKey))
+        NSUserDefaults.standardUserDefaults.setObject(languageCode, forKey = selectedAppLanguageKey)
     }
 
     actual fun applySelectedAppLanguage(languageCode: String) = Unit
@@ -53,8 +54,11 @@ actual object ThemeSettingsStorage {
     }
 
     actual fun replaceFromSyncPayload(payload: JsonObject) {
-        syncKeys.forEach { key ->
+        profileScopedSyncKeys.forEach { key ->
             NSUserDefaults.standardUserDefaults.removeObjectForKey(ProfileScopedKey.of(key))
+        }
+        globalSyncKeys.forEach { key ->
+            NSUserDefaults.standardUserDefaults.removeObjectForKey(key)
         }
 
         payload.decodeSyncString(selectedThemeKey)?.let(::saveSelectedTheme)

--- a/composeApp/src/iosMain/kotlin/com/nuvio/app/features/settings/ThemeSettingsStorage.ios.kt
+++ b/composeApp/src/iosMain/kotlin/com/nuvio/app/features/settings/ThemeSettingsStorage.ios.kt
@@ -38,8 +38,13 @@ actual object ThemeSettingsStorage {
         NSUserDefaults.standardUserDefaults.setBool(enabled, forKey = ProfileScopedKey.of(amoledEnabledKey))
     }
 
-    actual fun loadSelectedAppLanguage(): String? =
-        NSUserDefaults.standardUserDefaults.stringForKey(selectedAppLanguageKey)
+    actual fun loadSelectedAppLanguage(): String? {
+        val value = NSUserDefaults.standardUserDefaults.stringForKey(selectedAppLanguageKey)
+        if (value != null) return value
+        val legacy = NSUserDefaults.standardUserDefaults.stringForKey(ProfileScopedKey.of(selectedAppLanguageKey))
+        if (legacy != null) saveSelectedAppLanguage(legacy)
+        return legacy
+    }
 
     actual fun saveSelectedAppLanguage(languageCode: String) {
         NSUserDefaults.standardUserDefaults.setObject(languageCode, forKey = selectedAppLanguageKey)


### PR DESCRIPTION
  ## Summary

  Bug: when the active profile is anything other than profile 1, the app
  language resets to English on every restart. Profile 1 works fine by
  coincidence.

  The language was being stored under a profile-scoped key, but it's read at
  startup before the active profile is loaded — so it always reads with the
  default profile id and misses for anyone on profile 2+.

  Fix: made the language key global (it's a device-level setting, not
  per-profile). Also noticed that the profile cache loader wasn't notifying the
  theme settings repository, so theme/AMOLED had the same kind of issue silently
   — fixed that too. Added a fallback read of the old key so existing users
  don't lose their language on the first launch after the update.

  ## PR type

  - Bug fix

  ## Why

  App language is a device/user preference, not per-profile, so the storage key
  shouldn't be scoped. Scoping it caused a startup race where the key was read
  with the default `activeProfileId = 1` before the real profile was loaded,
  resetting non-primary profiles to English on every launch.

  ## Policy check

  - This PR is not cosmetic-only, unless it is a translation PR.
  - This PR does not add a new major feature without prior approval.
  - This PR is small in scope and focused on one problem.
  - It's not a major update.

  ## Approved feature request (required for large/non-trivial PRs)

  None

  ## Testing

  None

  ## Screenshots / Video (UI changes only)

  None

  ## Breaking changes

  None — legacy profile-scoped key is read as fallback and migrated
  transparently on first read.

  ## Linked issues

  Closes #874