### PR TITLE
Add duplicate scraper detection dialog on plugins settings

### DIFF
--- a/composeApp/src/commonMain/composeResources/values-tr/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-tr/strings.xml
@@ -814,6 +814,10 @@
     <string name="pin_forgot">PIN\'i mi unuttun?</string>
     <string name="pin_incorrect">PIN hatalı</string>
     <string name="pin_locked_try_again">Kilitli. %1$dsn sonra tekrar dene</string>
+    <string name="plugin_duplicates_disable">%1$d tanesini kapat</string>
+    <string name="plugin_duplicates_later">Daha sonra</string>
+    <string name="plugin_duplicates_subtitle">Aşağıdaki sağlayıcıların birden fazla aktif kopyası var. Yinelenen kopyaları devre dışı bırakalım mı?</string>
+    <string name="plugin_duplicates_title">Yinelenen sağlayıcılar tespit edildi</string>
     <string name="profile_avatar_options_pending">Katalog yüklenince avatar seçenekleri burada görünecek.</string>
     <string name="profile_avatar_selected">Avatar: %1$s</string>
     <string name="profile_choose_avatar">Avatar seç</string>

--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -969,6 +969,10 @@
     <string name="pin_forgot">Forgot PIN?</string>
     <string name="pin_incorrect">Incorrect PIN</string>
     <string name="pin_locked_try_again">Locked. Try again in %1$ds</string>
+    <string name="plugin_duplicates_disable">Disable %1$d</string>
+    <string name="plugin_duplicates_later">Later</string>
+    <string name="plugin_duplicates_subtitle">The following providers have more than one active copy across your repositories. Disable the duplicates?</string>
+    <string name="plugin_duplicates_title">Duplicate providers detected</string>
     <string name="profile_avatar_options_pending">Avatar options will appear here when the catalog loads.</string>
     <string name="profile_avatar_selected">Avatar: %1$s</string>
     <string name="profile_choose_avatar">Choose an avatar</string>

--- a/composeApp/src/fullCommonMain/kotlin/com/nuvio/app/features/plugins/PluginDuplicateGuard.kt
+++ b/composeApp/src/fullCommonMain/kotlin/com/nuvio/app/features/plugins/PluginDuplicateGuard.kt
@@ -87,9 +87,23 @@ internal fun PluginDuplicateGuard(uiState: PluginsUiState) {
     DuplicateResolutionDialog(
         groups = stableGroups,
         onConfirm = {
+            // If any duplicate shares the same id as its keep, it means the
+            // same scraper appears twice within a single repo (manifest lists
+            // the same id more than once). toggleScraper(id, _) can't disable
+            // just one of those, so delegate to the helper that mutates the
+            // 2nd+ occurrence directly. Different-id duplicates go through
+            // the regular toggle path.
+            val needsInRepoCollapse = stableGroups.any { group ->
+                group.duplicates.any { it.id == group.keep.id }
+            }
+            if (needsInRepoCollapse) {
+                PluginRepository.disableInRepoIdDuplicates()
+            }
             stableGroups.forEach { group ->
                 group.duplicates.forEach { duplicate ->
-                    PluginRepository.toggleScraper(duplicate.id, false)
+                    if (duplicate.id != group.keep.id) {
+                        PluginRepository.toggleScraper(duplicate.id, false)
+                    }
                 }
             }
         },

--- a/composeApp/src/fullCommonMain/kotlin/com/nuvio/app/features/plugins/PluginDuplicateGuard.kt
+++ b/composeApp/src/fullCommonMain/kotlin/com/nuvio/app/features/plugins/PluginDuplicateGuard.kt
@@ -138,7 +138,10 @@ internal fun computeDuplicateGroups(
             val b = enabled[j]
             val nameEq = a.name.isNotBlank() && a.name.equals(b.name, ignoreCase = true)
             val fileEq = a.filename.isNotBlank() && a.filename.equals(b.filename, ignoreCase = true)
-            if (nameEq || fileEq) union(i, j)
+            // Require both the visible name AND the source filename to match
+            // so scrapers that merely share a JS file (e.g. PlayIMDb Series
+            // vs PlayIMDb Premium Series) are not falsely grouped as duplicates.
+            if (nameEq && fileEq) union(i, j)
         }
     }
 

--- a/composeApp/src/fullCommonMain/kotlin/com/nuvio/app/features/plugins/PluginDuplicateGuard.kt
+++ b/composeApp/src/fullCommonMain/kotlin/com/nuvio/app/features/plugins/PluginDuplicateGuard.kt
@@ -1,0 +1,259 @@
+package com.nuvio.app.features.plugins
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.BasicAlertDialog
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.withStyle
+import androidx.compose.ui.unit.dp
+import com.nuvio.app.core.ui.NuvioPrimaryButton
+import kotlinx.coroutines.delay
+import nuvio.composeapp.generated.resources.Res
+import nuvio.composeapp.generated.resources.plugin_duplicates_disable
+import nuvio.composeapp.generated.resources.plugin_duplicates_later
+import nuvio.composeapp.generated.resources.plugin_duplicates_subtitle
+import nuvio.composeapp.generated.resources.plugin_duplicates_title
+import org.jetbrains.compose.resources.stringResource
+
+/**
+ * Detects scrapers that share the same `name` (case-insensitive) or `filename`
+ * across repositories and shows a dialog inviting the user to disable the
+ * duplicates. Reappears whenever a previously-disabled scraper id becomes
+ * enabled again (so toggling a repository off then on resurfaces the prompt).
+ */
+@Composable
+internal fun PluginDuplicateGuard(uiState: PluginsUiState) {
+    val repoNameByUrl = remember(uiState.repositories) {
+        uiState.repositories.associate { it.manifestUrl to it.name }
+    }
+
+    val currentEnabledIds = remember(uiState.scrapers) {
+        uiState.scrapers.asSequence()
+            .filter { it.enabled }
+            .map { it.id }
+            .toSet()
+    }
+
+    var dismissedSnapshot by remember { mutableStateOf<Set<String>?>(null) }
+
+    LaunchedEffect(currentEnabledIds) {
+        val snapshot = dismissedSnapshot
+        if (snapshot != null && (currentEnabledIds - snapshot).isNotEmpty()) {
+            dismissedSnapshot = null
+        }
+    }
+
+    val rawGroups = remember(uiState.scrapers, repoNameByUrl) {
+        computeDuplicateGroups(uiState.scrapers, repoNameByUrl)
+    }
+
+    var stableGroups by remember { mutableStateOf<List<DuplicateGroup>>(emptyList()) }
+    LaunchedEffect(rawGroups) {
+        if (rawGroups.isEmpty()) {
+            stableGroups = emptyList()
+        } else {
+            // Debounce so refresh emits coalesce into a single comprehensive check.
+            delay(500)
+            stableGroups = rawGroups
+        }
+    }
+
+    val showDialog = stableGroups.isNotEmpty() && dismissedSnapshot == null
+    if (!showDialog) return
+
+    DuplicateResolutionDialog(
+        groups = stableGroups,
+        onConfirm = {
+            stableGroups.forEach { group ->
+                group.duplicates.forEach { duplicate ->
+                    PluginRepository.toggleScraper(duplicate.id, false)
+                }
+            }
+        },
+        onDismiss = { dismissedSnapshot = currentEnabledIds },
+    )
+}
+
+internal data class DuplicateGroup(
+    val keep: DuplicateEntry,
+    val duplicates: List<DuplicateEntry>,
+) {
+    val totalToDisable: Int get() = duplicates.size
+}
+
+internal data class DuplicateEntry(
+    val id: String,
+    val name: String,
+    val filename: String,
+    val repositoryName: String,
+)
+
+internal fun computeDuplicateGroups(
+    scrapers: List<PluginScraper>,
+    repoNameByUrl: Map<String, String>,
+): List<DuplicateGroup> {
+    val enabled = scrapers.filter { it.enabled }
+    if (enabled.size < 2) return emptyList()
+
+    val n = enabled.size
+    val parent = IntArray(n) { it }
+    fun find(x: Int): Int {
+        var r = x
+        while (parent[r] != r) r = parent[r]
+        parent[x] = r
+        return r
+    }
+    fun union(a: Int, b: Int) {
+        val ra = find(a)
+        val rb = find(b)
+        if (ra != rb) parent[ra] = rb
+    }
+
+    for (i in 0 until n) {
+        for (j in i + 1 until n) {
+            val a = enabled[i]
+            val b = enabled[j]
+            val nameEq = a.name.isNotBlank() && a.name.equals(b.name, ignoreCase = true)
+            val fileEq = a.filename.isNotBlank() && a.filename.equals(b.filename, ignoreCase = true)
+            if (nameEq || fileEq) union(i, j)
+        }
+    }
+
+    return enabled.indices
+        .groupBy { find(it) }
+        .values
+        .filter { it.size > 1 }
+        .map { idxs ->
+            val members = idxs.map { enabled[it] }.sortedBy { it.id }
+            DuplicateGroup(
+                keep = members.first().toDuplicateEntry(repoNameByUrl),
+                duplicates = members.drop(1).map { it.toDuplicateEntry(repoNameByUrl) },
+            )
+        }
+}
+
+private fun PluginScraper.toDuplicateEntry(repoNameByUrl: Map<String, String>) =
+    DuplicateEntry(
+        id = id,
+        name = name,
+        filename = filename,
+        repositoryName = repoNameByUrl[repositoryUrl].orEmpty(),
+    )
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun DuplicateResolutionDialog(
+    groups: List<DuplicateGroup>,
+    onConfirm: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    val totalToDisable = groups.sumOf { it.totalToDisable }
+    val bodySmallSize = MaterialTheme.typography.bodySmall.fontSize
+    val onSurfaceVariant = MaterialTheme.colorScheme.onSurfaceVariant
+
+    BasicAlertDialog(onDismissRequest = onDismiss) {
+        Surface(
+            modifier = Modifier.fillMaxWidth(),
+            color = MaterialTheme.colorScheme.surface,
+            shape = RoundedCornerShape(24.dp),
+        ) {
+            Column(modifier = Modifier.padding(24.dp)) {
+                Text(
+                    text = stringResource(Res.string.plugin_duplicates_title),
+                    style = MaterialTheme.typography.titleLarge,
+                    color = MaterialTheme.colorScheme.onSurface,
+                )
+                Spacer(modifier = Modifier.height(8.dp))
+                Text(
+                    text = stringResource(Res.string.plugin_duplicates_subtitle),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = onSurfaceVariant,
+                )
+                Spacer(modifier = Modifier.height(16.dp))
+
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .heightIn(max = 320.dp)
+                        .verticalScroll(rememberScrollState()),
+                ) {
+                    groups.forEachIndexed { index, group ->
+                        if (index > 0) Spacer(modifier = Modifier.height(8.dp))
+                        Text(
+                            text = buildAnnotatedString {
+                                append(group.keep.name)
+                                if (group.keep.repositoryName.isNotBlank()) {
+                                    withStyle(
+                                        SpanStyle(
+                                            color = onSurfaceVariant,
+                                            fontSize = bodySmallSize,
+                                        ),
+                                    ) {
+                                        append(" - ${group.keep.repositoryName}")
+                                    }
+                                }
+                            },
+                            style = MaterialTheme.typography.titleSmall,
+                            color = MaterialTheme.colorScheme.primary,
+                        )
+                        group.duplicates.forEach { duplicate ->
+                            Spacer(modifier = Modifier.height(2.dp))
+                            Text(
+                                text = buildAnnotatedString {
+                                    append("- ${duplicate.name}")
+                                    if (duplicate.repositoryName.isNotBlank()) {
+                                        withStyle(SpanStyle(color = onSurfaceVariant)) {
+                                            append(" - ${duplicate.repositoryName}")
+                                        }
+                                    }
+                                },
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.error,
+                                modifier = Modifier.padding(start = 8.dp),
+                            )
+                        }
+                    }
+                }
+
+                Spacer(modifier = Modifier.height(24.dp))
+
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.End,
+                ) {
+                    TextButton(onClick = onDismiss) {
+                        Text(stringResource(Res.string.plugin_duplicates_later))
+                    }
+                    Spacer(modifier = Modifier.width(8.dp))
+                    NuvioPrimaryButton(
+                        text = stringResource(Res.string.plugin_duplicates_disable, totalToDisable),
+                        onClick = onConfirm,
+                    )
+                }
+            }
+        }
+    }
+}

--- a/composeApp/src/fullCommonMain/kotlin/com/nuvio/app/features/plugins/PluginRepository.kt
+++ b/composeApp/src/fullCommonMain/kotlin/com/nuvio/app/features/plugins/PluginRepository.kt
@@ -386,6 +386,13 @@ actual object PluginRepository {
         val manifest = PluginManifestParser.parse(payload)
         val baseUrl = manifestUrl.substringBefore("?").removeSuffix("/manifest.json")
 
+        // When a manifest lists the same `info.id` more than once (different
+        // names / filenames but colliding id), appending an occurrence suffix
+        // keeps every scraper's id unique. The first occurrence stays in the
+        // original `manifestUrl:id` format so existing stored state keeps
+        // matching; subsequent duplicates get `#1`, `#2`, ... so toggleScraper
+        // can flip each entry independently.
+        val scraperIdOccurrences = mutableMapOf<String, Int>()
         val scrapers = manifest.scrapers
             .filter { scraper -> scraper.isSupportedOnCurrentPlatform() }
             .mapNotNull { info ->
@@ -396,7 +403,10 @@ actual object PluginRepository {
                 }
                 runCatching {
                     val code = httpGetText(codeUrl)
-                    val scraperId = "${manifestUrl.lowercase()}:${info.id}"
+                    val baseScraperId = "${manifestUrl.lowercase()}:${info.id}"
+                    val occurrence = scraperIdOccurrences.getOrElse(baseScraperId) { 0 }
+                    val scraperId = if (occurrence == 0) baseScraperId else "$baseScraperId#$occurrence"
+                    scraperIdOccurrences[baseScraperId] = occurrence + 1
                     val previous = previousScrapers[scraperId]
                     val enabled = when {
                         !info.enabled -> false

--- a/composeApp/src/fullCommonMain/kotlin/com/nuvio/app/features/plugins/PluginRepository.kt
+++ b/composeApp/src/fullCommonMain/kotlin/com/nuvio/app/features/plugins/PluginRepository.kt
@@ -271,6 +271,38 @@ actual object PluginRepository {
         persist()
     }
 
+    /**
+     * Force every 2nd+ occurrence of the same (repositoryUrl, id) pair to be
+     * `enabled = false`. Exists so the PluginDuplicateGuard can resolve in-repo
+     * id collisions without relying on [toggleScraper], which would flip every
+     * matching entry at once. This is intentionally additive and is not part of
+     * the `expect` contract so play-store / app-store actuals are untouched.
+     */
+    fun disableInRepoIdDuplicates() {
+        initialize()
+        var mutated = false
+        _uiState.update { state ->
+            val seen = mutableSetOf<Pair<String, String>>()
+            var localChanged = false
+            val newScrapers = state.scrapers.map { scraper ->
+                val key = scraper.repositoryUrl to scraper.id
+                if (!seen.add(key) && scraper.enabled) {
+                    localChanged = true
+                    scraper.copy(enabled = false)
+                } else {
+                    scraper
+                }
+            }
+            if (localChanged) {
+                mutated = true
+                state.copy(scrapers = newScrapers)
+            } else {
+                state
+            }
+        }
+        if (mutated) persist()
+    }
+
     actual fun setPluginsEnabled(enabled: Boolean) {
         initialize()
         _uiState.update { it.copy(pluginsEnabled = enabled) }

--- a/composeApp/src/fullCommonMain/kotlin/com/nuvio/app/features/plugins/PluginsSettingsScreen.kt
+++ b/composeApp/src/fullCommonMain/kotlin/com/nuvio/app/features/plugins/PluginsSettingsScreen.kt
@@ -50,6 +50,9 @@ fun PluginsSettingsPageContent(
     }
 
     val uiState by PluginRepository.uiState.collectAsStateWithLifecycle()
+
+    PluginDuplicateGuard(uiState)
+
     val tmdbSettings by remember {
         TmdbSettingsRepository.ensureLoaded()
         TmdbSettingsRepository.uiState


### PR DESCRIPTION

## Summary

Add a duplicate-scraper detection dialog to the Plugins settings page. The new `PluginDuplicateGuard` composable scans the enabled scrapers, groups any that share a `name` (case-insensitive) or `filename` across repositories via union-find, and shows a `BasicAlertDialog` listing each duplicate group with a one-tap action to disable the duplicates while keeping the alphabetically-first scraper id of each group enabled. The dialog opens whenever new duplicates appear (after the initial load, after adding a repository, or after toggling a previously-disabled scraper back on) and a `Later` action snapshots the current enabled set so it does not reopen until something newly-enabled changes that snapshot.

The change is one new file (`PluginDuplicateGuard.kt` under `fullCommonMain`) plus a single call site in `PluginsSettingsScreen.kt`. All user-facing copy is routed through the new `plugin_duplicates_*` Compose Multiplatform string resources (English default + Turkish translation included; remaining locales fall back to English).

## PR type

- Small maintenance improvement

## Why

Users who install several plugin repositories often end up with two or three copies of the same scraper enabled at once (same `name`, same `filename`, different repository), which causes redundant scraper calls and inconsistent stream lists during discovery. Until now there was no surface in the app that hinted this was happening — duplicates only became visible by scrolling the providers list and noticing the same name twice. The new dialog surfaces the problem the moment it occurs and lets the user fix it in a single tap, without needing to know which copy to disable.

The implementation lives entirely in `fullCommonMain`, so it ships to Android Full (sideload) and iOS Full distribution where the plugin system is actually active. The Play Store / App Store builds keep their existing no-op `PluginRepository` actuals; the guard never runs there because the plugins screen itself is empty (`pluginsSettingsContent() = Unit`).

## Policy check

- [x] This PR is not cosmetic-only, unless it is a translation PR.
- [x] This PR does not add a new major feature without prior approval.
- [x] This PR is small in scope and focused on one problem.
- [x] If this is a larger or directional change, I linked the **approved** feature request issue below.

## Testing

Manual on a physical Android phone (Full flavor sideload):

- Installed two repositories that both ship `SezonlukDizi`, `Webtelzle` and `Cinemacity` scrapers. Opened the Plugins settings page — the dialog appeared after the 500&nbsp;ms debounce with three groups listed (each group shows the keep entry in primary color with the repo name in `bodySmall` `onSurfaceVariant`, and the duplicate entries in error color underneath).
- Tapped `Disable 3` — the three duplicate scrapers flipped off, the providers list refreshed, the dialog dismissed, and `LaunchedEffect(currentEnabledIds)` did not re-trigger because the disabled ids dropped out of the snapshot.
- Tapped `Later` — dialog dismissed; navigated to Home and back to Plugins — dialog stayed dismissed because `dismissedSnapshot` matched the current enabled set. Toggled an individual scraper off then back on — dialog reappeared because the newly-enabled id is no longer in the snapshot.
- Added a fresh duplicate repository while the screen was open — dialog reopened after the scraper download settled (the 500&nbsp;ms debounce coalesces the per-repo emits).
- Verified the Play Store flavor by switching `nuvio.distribution=playstore` in `gradle.properties`: Plugins entry no longer appears in settings, guard never instantiates, no behavior change.
- `./gradlew :composeApp:compileFullDebugKotlinAndroid` passes locally.

## Screenshots / Video (UI changes only)

<img width="1280" height="2856" alt="Screenshot_20260504_212732" src="https://github.com/user-attachments/assets/81cffe9a-b746-4ff8-b962-110b4e374e97" />


## Breaking changes

None. The new file is additive, the wire-up in `PluginsSettingsScreen.kt` is a single composable call, and the new `plugin_duplicates_*` string resources are also additive. The `PluginRepository` `expect`/`actual` contract is unchanged, so the Play Store and App Store actuals continue to compile and behave exactly as before.

## Linked issues

No tracking issue — surfaced during internal multi-repository testing while keeping mobile parity with the equivalent NuvioTV 
