### PR TITLE
feat: add followRedirects support to httpRequestRaw and PluginRuntime

### DIFF
--- a/composeApp/src/androidMain/kotlin/com/nuvio/app/features/addons/AddonPlatform.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/nuvio/app/features/addons/AddonPlatform.android.kt
@@ -210,6 +210,7 @@ actual suspend fun httpRequestRaw(
     url: String,
     headers: Map<String, String>,
     body: String,
+    followRedirects: Boolean,
 ): RawHttpResponse =
     withContext(Dispatchers.IO) {
         val normalizedMethod = method.uppercase()
@@ -228,7 +229,16 @@ actual suspend fun httpRequestRaw(
             builder.method(normalizedMethod, null)
         }.build()
 
-        addonHttpClient.newCall(request).execute().use { response ->
+        val client = if (followRedirects) {
+            addonHttpClient
+        } else {
+            addonHttpClient.newBuilder()
+                .followRedirects(false)
+                .followSslRedirects(false)
+                .build()
+        }
+
+        client.newCall(request).execute().use { response ->
             RawHttpResponse(
                 status = response.code,
                 statusText = response.message,

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/addons/AddonPlatform.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/addons/AddonPlatform.kt
@@ -33,4 +33,5 @@ expect suspend fun httpRequestRaw(
     url: String,
     headers: Map<String, String>,
     body: String,
+    followRedirects: Boolean = true,
 ): RawHttpResponse

--- a/composeApp/src/fullCommonMain/kotlin/com/nuvio/app/features/plugins/PluginRuntime.kt
+++ b/composeApp/src/fullCommonMain/kotlin/com/nuvio/app/features/plugins/PluginRuntime.kt
@@ -103,8 +103,9 @@ internal object PluginRuntime {
                     val method = args.getOrNull(1)?.toString() ?: "GET"
                     val headersJson = args.getOrNull(2)?.toString() ?: "{}"
                     val body = args.getOrNull(3)?.toString() ?: ""
+                    val followRedirects = args.getOrNull(4) as? Boolean ?: true
                     try {
-                        performNativeFetch(url, method, headersJson, body)
+                        performNativeFetch(url, method, headersJson, body, followRedirects)
                     } catch (t: Throwable) {
                         log.e(t) { "Fetch bridge error for $method $url" }
                         JsonObject(
@@ -315,6 +316,7 @@ internal object PluginRuntime {
         method: String,
         headersJson: String,
         body: String,
+        followRedirects: Boolean,
     ): String {
         return try {
             val headers = parseHeaders(headersJson).toMutableMap()
@@ -328,6 +330,7 @@ internal object PluginRuntime {
                     url = url,
                     headers = headers,
                     body = body,
+                    followRedirects = followRedirects,
                 )
             }
 
@@ -490,7 +493,8 @@ internal object PluginRuntime {
                 var method = (options.method || 'GET').toUpperCase();
                 var headers = options.headers || {};
                 var body = options.body || '';
-                var result = __native_fetch(url, method, JSON.stringify(headers), body);
+                var followRedirects = options.redirect !== 'manual';
+                var result = __native_fetch(url, method, JSON.stringify(headers), body, followRedirects);
                 var parsed = JSON.parse(result);
                 return {
                     ok: parsed.ok,

--- a/composeApp/src/iosMain/kotlin/com/nuvio/app/features/addons/AddonPlatform.ios.kt
+++ b/composeApp/src/iosMain/kotlin/com/nuvio/app/features/addons/AddonPlatform.ios.kt
@@ -132,6 +132,7 @@ actual suspend fun httpRequestRaw(
     url: String,
     headers: Map<String, String>,
     body: String,
+    followRedirects: Boolean,
 ): RawHttpResponse =
     addonHttpClient
         .request {


### PR DESCRIPTION
## Summary

Changes Added:
   1. Network Layer (AddonPlatform.kt, .android.kt, .ios.kt):
      Added the followRedirects: Boolean parameter to the
      httpRequestRaw function. Android's OkHttpClient now
      conditionally creates a new client with redirects
      disabled when requested.
   2. Plugin Runtime (PluginRuntime.kt): Updated the
      __native_fetch bridge to receive the followRedirects
      parameter.
   3. Fetch Polyfill (PluginRuntime.kt): Updated the injected
      JavaScript fetch polyfill to correctly parse the
      options.redirect !== 'manual' flag and pass it down to
      the native layer.


## PR type

<!-- Pick one and delete the others -->
- Small maintenance improvement

## Why


  With these changes, plugins like NetMirror that rely on
  redirect: 'manual' to intercept and extract cookies from 302
  Found responses will now work correctly within the Nuvio
  app.

## Policy check

<!-- ALL boxes must be checked or the PR will be closed without review. -->
- [ ] This PR is not cosmetic-only, unless it is a translation PR.
- [ ] This PR does not add a new major feature without prior approval.
- [x] This PR is small in scope and focused on one problem.
- [ ] If this is a larger or directional change, I linked the **approved** feature request issue below.


## Approved feature request (required for large/non-trivial PRs)


## Breaking changes

none

## Linked issues


>https://github.com/yoruix/nuvio-providers/issues/50