### PR TITLE
feat: double tap on search tab to focus on search input

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/App.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/App.kt
@@ -520,6 +520,7 @@ private fun MainAppContent(
         val hapticFeedback = LocalHapticFeedback.current
         val coroutineScope = rememberCoroutineScope()
         var selectedTab by rememberSaveable { mutableStateOf(AppScreenTab.Home) }
+        var searchFocusRequestCount by remember { mutableStateOf(0) }
         val currentBackStackEntry by navController.currentBackStackEntryAsState()
         val nativeRequestedTab by remember { NativeTabBridge.requestedTab }.collectAsStateWithLifecycle()
         val liquidGlassNativeTabBarEnabled by remember {
@@ -583,6 +584,9 @@ private fun MainAppContent(
 
     LaunchedEffect(selectedTab) {
         NativeTabBridge.publishSelectedTab(selectedTab.toNativeNavigationTab())
+        if (selectedTab != AppScreenTab.Search) {
+            searchFocusRequestCount = 0
+        }
     }
 
     DisposableEffect(
@@ -1009,7 +1013,13 @@ private fun MainAppContent(
                                         )
                                         NavItem(
                                             selected = selectedTab == AppScreenTab.Search,
-                                            onClick = { selectedTab = AppScreenTab.Search },
+                                            onClick = {
+                                                if (selectedTab == AppScreenTab.Search) {
+                                                    searchFocusRequestCount++
+                                                } else {
+                                                    selectedTab = AppScreenTab.Search
+                                                }
+                                            },
                                             icon = Res.drawable.sidebar_search,
                                             contentDescription = stringResource(Res.string.compose_nav_search),
                                         )
@@ -1043,6 +1053,7 @@ private fun MainAppContent(
                                             .fillMaxSize()
                                             .padding(innerPadding),
                                         selectedTab = selectedTab,
+                                        searchFocusRequestCount = searchFocusRequestCount,
                                         animateHomeCollectionGifs = tabsRouteActive,
                                         onCatalogClick = onCatalogClick,
                                         onPosterClick = { meta ->
@@ -1097,7 +1108,13 @@ private fun MainAppContent(
                                 if (isTabletLayout && !useNativeBottomTabs) {
                                     TabletFloatingTopBar(
                                         selectedTab = selectedTab,
-                                        onTabSelected = { selectedTab = it },
+                                        onTabSelected = { tab ->
+                                            if (tab == AppScreenTab.Search && selectedTab == AppScreenTab.Search) {
+                                                searchFocusRequestCount++
+                                            } else {
+                                                selectedTab = tab
+                                            }
+                                        },
                                         onProfileSelected = onProfileSelected,
                                         onAddProfileRequested = onSwitchProfile,
                                     )
@@ -1975,6 +1992,7 @@ private fun rememberGuardedPopBackStack(
 private fun AppTabHost(
     selectedTab: AppScreenTab,
     modifier: Modifier = Modifier,
+    searchFocusRequestCount: Int = 0,
     animateHomeCollectionGifs: Boolean = true,
     onCatalogClick: ((HomeCatalogSection) -> Unit)? = null,
     onPosterClick: ((MetaPreview) -> Unit)? = null,
@@ -2022,6 +2040,7 @@ private fun AppTabHost(
                         modifier = Modifier.fillMaxSize(),
                         onPosterClick = onPosterClick,
                         onPosterLongClick = onPosterLongClick,
+                        searchFocusRequestCount = searchFocusRequestCount,
                     )
                 }
 

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/search/SearchScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/search/SearchScreen.kt
@@ -33,6 +33,8 @@ import androidx.compose.runtime.snapshotFlow
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.Alignment
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.text.font.FontWeight
@@ -80,7 +82,16 @@ fun SearchScreen(
     modifier: Modifier = Modifier,
     onPosterClick: ((MetaPreview) -> Unit)? = null,
     onPosterLongClick: ((MetaPreview) -> Unit)? = null,
+    searchFocusRequestCount: Int = 0,
 ) {
+    val focusRequester = remember { FocusRequester() }
+
+    LaunchedEffect(searchFocusRequestCount) {
+        if (searchFocusRequestCount > 0) {
+            focusRequester.requestFocus()
+        }
+    }
+
     LaunchedEffect(Unit) {
         AddonRepository.initialize()
         WatchedRepository.ensureLoaded()
@@ -240,6 +251,7 @@ fun SearchScreen(
                         value = query,
                         onValueChange = { query = it },
                         placeholder = stringResource(Res.string.compose_search_placeholder),
+                        modifier = Modifier.focusRequester(focusRequester),
                         trailingContent = if (query.isNotBlank()) {
                             {
                                 IconButton(onClick = { query = "" }) {


### PR DESCRIPTION
## Summary

Set the focus on the search input when the user double tap on search tab. This is to quickly trigger search and improve UX.

## PR type
- Small maintenance improvement

## Why
To improve UX

## Policy check
- [x] This PR is not cosmetic-only, unless it is a translation PR.
- [x] This PR does not add a new major feature without prior approval.
- [x] This PR is small in scope and focused on one problem.

## Approved feature request (required for large/non-trivial PRs)
N.A

## Testing
- Go to "Search" tab, focus is not set on the search input.
- Click on "Search tab again, the focus is set to search input.
- Move away from "Search" tab and come back, the focus is not set to search input.
- Click again on "Search" tab, the focus is set to search input.

## Screenshots / Video (UI changes only)
N.A

## Breaking changes
N.A

## Linked issues
N.A
